### PR TITLE
Making the `trace` parameter moderately useful

### DIFF
--- a/lib/toisb.rb
+++ b/lib/toisb.rb
@@ -1,7 +1,7 @@
 require_relative "toisb/wrapper"
 
 module TOISB
-  def self.wrap object
-    Wrapper.new object, caller
+  def self.wrap object, trace = nil
+    Wrapper.new object, (trace || caller)
   end
 end

--- a/lib/toisb/wrapper.rb
+++ b/lib/toisb/wrapper.rb
@@ -1,7 +1,7 @@
 module TOISB; class Wrapper
   def initialize object, trace = nil
     @object = object
-    @trace = caller
+    @trace = trace || caller
   end
   attr_reader :object, :trace
 

--- a/uspec/trace_spec.rb
+++ b/uspec/trace_spec.rb
@@ -1,0 +1,24 @@
+require_relative "uspec_helper"
+
+class ::TestObject < BasicObject; end
+obj = ::TestObject.new
+
+spec "can skip trace arg and @trace will still be set" do
+  toisb = TOISB.wrap obj
+  actual = toisb.instance_variable_get :trace
+  actual.is_a?(Array) || actual
+end
+
+spec "can pass nil as trace and @trace will still be set" do
+  arg = nil
+  toisb = TOISB.wrap obj, arg
+  actual = toisb.instance_variable_get :trace
+  actual.is_a?(Array) || actual
+end
+
+spec "other values passed as trace and @trace will equal it" do
+  expected = "foo"
+  toisb = TOISB.wrap obj, arg
+  actual = toisb.instance_variable_get :trace
+  (actual == expected) || actual
+end

--- a/uspec/trace_spec.rb
+++ b/uspec/trace_spec.rb
@@ -18,7 +18,7 @@ end
 
 spec "other values passed as trace and @trace will equal it" do
   expected = "foo"
-  toisb = TOISB.wrap obj, arg
+  toisb = TOISB.wrap obj, expected
   actual = toisb.instance_variable_get :@trace
   (actual == expected) || actual
 end

--- a/uspec/trace_spec.rb
+++ b/uspec/trace_spec.rb
@@ -5,20 +5,20 @@ obj = ::TestObject.new
 
 spec "can skip trace arg and @trace will still be set" do
   toisb = TOISB.wrap obj
-  actual = toisb.instance_variable_get :trace
+  actual = toisb.instance_variable_get :@trace
   actual.is_a?(Array) || actual
 end
 
 spec "can pass nil as trace and @trace will still be set" do
   arg = nil
   toisb = TOISB.wrap obj, arg
-  actual = toisb.instance_variable_get :trace
+  actual = toisb.instance_variable_get :@trace
   actual.is_a?(Array) || actual
 end
 
 spec "other values passed as trace and @trace will equal it" do
   expected = "foo"
   toisb = TOISB.wrap obj, arg
-  actual = toisb.instance_variable_get :trace
+  actual = toisb.instance_variable_get :@trace
   (actual == expected) || actual
 end


### PR DESCRIPTION
It is mostly for debugging, so when this object is wrapped we can figure out where it came from. I allow it to be overwritten so that the most likely culprit can be implicated when its used in metaprogramming.

Fixes #1 